### PR TITLE
Update Bogus to 24.2.0 to fix DateTime errors

### DIFF
--- a/src/AutoBogus.Tests.NET45/AutoBogus.Tests.NET45.csproj
+++ b/src/AutoBogus.Tests.NET45/AutoBogus.Tests.NET45.csproj
@@ -69,8 +69,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Bogus, Version=22.0.8.0, Culture=neutral, PublicKeyToken=fa1bb3f3f218129a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Bogus.22.0.8\lib\net40\Bogus.dll</HintPath>
+    <Reference Include="Bogus, Version=24.2.0.0, Culture=neutral, PublicKeyToken=fa1bb3f3f218129a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Bogus.24.2.0\lib\net40\Bogus.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>

--- a/src/AutoBogus.Tests.NET45/packages.config
+++ b/src/AutoBogus.Tests.NET45/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Bogus" version="22.0.8" targetFramework="net45" />
+  <package id="Bogus" version="24.2.0" targetFramework="net45" />
   <package id="Castle.Core" version="4.2.0" targetFramework="net45" />
   <package id="FluentAssertions" version="5.4.0" targetFramework="net45" />
   <package id="NSubstitute" version="3.1.0" targetFramework="net45" />

--- a/src/AutoBogus/AutoBogus.csproj
+++ b/src/AutoBogus/AutoBogus.csproj
@@ -9,10 +9,11 @@
     <PackageProjectUrl>https://github.com/nickdodd79/AutoBogus</PackageProjectUrl>
     <Version>2.1.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="22.0.8" />
+    <PackageReference Include="Bogus" Version="24.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AutoBogus/Generators/EnumGenerator.cs
+++ b/src/AutoBogus/Generators/EnumGenerator.cs
@@ -2,7 +2,7 @@
 {
   internal sealed class EnumGenerator<TType>
     : IAutoGenerator
-    where TType: struct
+    where TType: struct, System.Enum
   {
     object IAutoGenerator.Generate(AutoGenerateContext context)
     {


### PR DESCRIPTION
Fixes #7

Update Bogus to fix `DateTime` and `DateTimeOffset` errors.

The problem is that Bogus now uses `System.Enum` generic contraints for Enum generation, so I had to use C# 7.3 to make AutoBogus compile again.