### PR TITLE
Add support for readonly IList properties (Protobuf RepeatedFields).

### DIFF
--- a/src/AutoBogus/AutoBogus.csproj
+++ b/src/AutoBogus/AutoBogus.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net40|AnyCPU'">
-    <DocumentationFile>D:\Projects\AutoBogus\src\AutoBogus\AutoBogus.xml</DocumentationFile>
+    <DocumentationFile>$(MSBuildProjectDirectory)\AutoBogus.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AutoBogus/AutoBogus.xml
+++ b/src/AutoBogus/AutoBogus.xml
@@ -9,6 +9,12 @@
             A class for binding generated instances.
             </summary>
         </member>
+        <member name="M:AutoBogus.AutoBinder.GetMembers(System.Type)">
+            <summary>
+            Allow read-only IList members because they can be set by adding items to the list.
+            </summary>
+            <returns>The full set of MemberInfos for injection.</returns>
+        </member>
         <member name="M:AutoBogus.AutoBinder.CreateInstance``1(AutoBogus.AutoGenerateContext)">
             <summary>
             Creates an instance of <typeparamref name="TType"/>.


### PR DESCRIPTION
I wanted to auto-generate test data for gRPC services, but ran into some issues using AutoBogus on the Protocol Buffers generated code:

1.  Protocol Buffers C# generated code contains readonly properties of type RepeatedField for lists of objects.
2.  The RepeatedField class only has a default constructor.

So I modified the AutoBinder to:
1.  Allow populating readonly properties implementing IList using IList.Add to copy items into the default constructed RepeatedField.
2.  Allow Enumerables that can't be populated via construction to be default constructed and populated later.