### PR TITLE
Specify a type argument for the GetMethod reflection call

### DIFF
--- a/src/AutoBogus/AutoBinder.cs
+++ b/src/AutoBogus/AutoBinder.cs
@@ -221,7 +221,7 @@ namespace AutoBogus
     private MethodInfo GetAddMethod(Type type)
     {
       // First try directly on the type
-      var method = type.GetMethod("Add");
+      var method = type.GetMethod("Add", new[] { typeof(ICollection) });
 
       if (method == null)
       {


### PR DESCRIPTION
Fix issue #22, avoid an AmbiguousMatchException.

FYI I was a little surprised that adding the ICollection argument didn't break the reflection call for a Dictionary and require further checks, but I tested and it didn't...