### PR TITLE
Add generator for System.Version

### DIFF
--- a/src/AutoBogus.Tests/AutoGeneratorsFixture.cs
+++ b/src/AutoBogus.Tests/AutoGeneratorsFixture.cs
@@ -286,6 +286,21 @@ namespace AutoBogus.Tests
       }
     }
 
+    public class VersionGenerator
+      : AutoGeneratorsFixture
+    {
+      [Fact]
+      public void Should_Populate_Version_Object()
+      {
+        var version = AutoFaker.Generate<Version>();
+
+        version.Major.Should().BeGreaterOrEqualTo(0);
+        version.Minor.Should().BeGreaterOrEqualTo(0);
+        version.Build.Should().BeGreaterOrEqualTo(0);
+        version.Revision.Should().BeGreaterOrEqualTo(0);
+      }
+    }
+
     public class GeneratorOverrides
       : AutoGeneratorsFixture
     {

--- a/src/AutoBogus/AutoGeneratorFactory.cs
+++ b/src/AutoBogus/AutoGeneratorFactory.cs
@@ -27,7 +27,8 @@ namespace AutoBogus
       {typeof(uint), new UIntGenerator()},
       {typeof(ulong), new ULongGenerator()},
       {typeof(Uri), new UriGenerator()},
-      {typeof(ushort), new UShortGenerator()}
+      {typeof(ushort), new UShortGenerator()},
+      {typeof(Version), new VersionGenerator()}
     };
 
     internal static IAutoGenerator GetGenerator(AutoGenerateContext context)

--- a/src/AutoBogus/Generators/VersionGenerator.cs
+++ b/src/AutoBogus/Generators/VersionGenerator.cs
@@ -1,0 +1,11 @@
+namespace AutoBogus.Generators
+{
+  internal sealed class VersionGenerator
+    : IAutoGenerator
+  {
+    object IAutoGenerator.Generate(AutoGenerateContext context)
+    {
+      return context.Faker.System.Version();
+    }
+  }
+}


### PR DESCRIPTION
In our project, we naively pointed AutoBogus at a type containing a `Version` property, and the resulting `Version` object was initialized in an odd way, with `Build` and `Revision` set to -1 and no bogus data in `Major` or `Minor`. This PR adds a default `VersionGenerator` to AutoBogus so that `Version` objects are generated with valid (non-negative) random integers in all properties.

A unit test verifies the new functionality.