### PR TITLE
Add the ability to override the FakerHub used by all Fakers

### DIFF
--- a/src/AutoBogus.Tests/AutoConfigBuilderFixture.cs
+++ b/src/AutoBogus.Tests/AutoConfigBuilderFixture.cs
@@ -22,6 +22,20 @@ namespace AutoBogus.Tests
       _builder = new AutoConfigBuilder(_config);
     }
 
+    public class WithFakerHub
+      : AutoConfigBuilderFixture
+    {
+      [Fact]
+      public void Should_Set_Config_FakerHub()
+      {
+        var fakerHub = new Faker();
+
+        _builder.WithFakerHub<ITestBuilder>(fakerHub, null);
+
+        _config.FakerHub.Should().Be(fakerHub);
+      }
+    }
+
     public class WithLocale
       : AutoConfigBuilderFixture
     {

--- a/src/AutoBogus.Tests/AutoFakerFixture.cs
+++ b/src/AutoBogus.Tests/AutoFakerFixture.cs
@@ -358,6 +358,39 @@ namespace AutoBogus.Tests
       }
     }
 
+    public class Caller_Supplied_FakerHub
+      : AutoFakerFixture
+    {
+      [Fact]
+      public void Should_Use_Caller_Supplied_FakerHub()
+      {
+        // We infer that our FakerHub was used by reseeding it and testing that we get the same sequence both times.
+        var fakerHub = new Faker();
+
+        var configure = CreateConfigure<IAutoGenerateConfigBuilder>(
+          AutoFaker.DefaultConfig,
+          builder => builder.WithFakerHub(fakerHub));
+
+        var faker = AutoFaker.Create(configure);
+
+        fakerHub.Random = new Randomizer(1);
+
+        var instance1 = faker.Generate<TestObject>();
+
+        fakerHub.Random = new Randomizer(1);
+
+        var instance2 = faker.Generate<TestObject>();
+
+        instance1.Should().BeEquivalentTo(instance2);
+      }
+
+      class TestObject
+      {
+        public int IntegerValue;
+        public string StringValue;
+      }
+    }
+
     public class Obsolete
     {
       #region Obsolete Instance

--- a/src/AutoBogus/AutoBogus.xml
+++ b/src/AutoBogus/AutoBogus.xml
@@ -453,6 +453,13 @@
             </summary>
             <typeparam name="TBuilder">The builder type.</typeparam>
         </member>
+        <member name="M:AutoBogus.IAutoConfigBuilder`1.WithFakerHub(Bogus.Faker)">
+            <summary>
+            Registers the Faker hub to use in underlying calls to Bogus.
+            </summary>
+            <param name="fakerHub">The Faker object to use as the faker hub</param>
+            <returns>The current configuration builder instance.</returns>
+        </member>
         <member name="M:AutoBogus.IAutoConfigBuilder`1.WithLocale(System.String)">
             <summary>
             Registers the locale to use when generating values.

--- a/src/AutoBogus/AutoConfig.cs
+++ b/src/AutoBogus/AutoConfig.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Bogus;
 
 namespace AutoBogus
 {
@@ -22,6 +23,7 @@ namespace AutoBogus
 
     internal AutoConfig(AutoConfig config)
     {
+      FakerHub = config.FakerHub;
       Locale = config.Locale;
       RepeatCount = config.RepeatCount;
       RecursiveDepth = config.RecursiveDepth;
@@ -30,6 +32,7 @@ namespace AutoBogus
       Overrides = config.Overrides.ToList();
     }
 
+    internal Faker FakerHub { get; set; }
     internal string Locale { get; set; }
     internal int RepeatCount { get; set; }
     internal int RecursiveDepth { get; set; }

--- a/src/AutoBogus/AutoConfigBuilder.cs
+++ b/src/AutoBogus/AutoConfigBuilder.cs
@@ -1,4 +1,5 @@
 using AutoBogus.Util;
+using Bogus;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,6 +19,7 @@ namespace AutoBogus
 
     internal object[] Args { get; private set; }
 
+    IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithFakerHub(Faker fakerHub) => WithFakerHub<IAutoFakerDefaultConfigBuilder>(fakerHub, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithLocale(string locale) => WithLocale<IAutoFakerDefaultConfigBuilder>(locale, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithRepeatCount(int count) => WithRepeatCount<IAutoFakerDefaultConfigBuilder>(count, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithRecursiveDepth(int depth) => WithRecursiveDepth<IAutoFakerDefaultConfigBuilder>(depth, this);
@@ -26,6 +28,7 @@ namespace AutoBogus
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithSkip<TType>(Expression<Func<TType, object>> member) => WithSkip<IAutoFakerDefaultConfigBuilder, TType>(member, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithOverride(AutoGeneratorOverride generatorOverride) => WithOverride<IAutoFakerDefaultConfigBuilder>(generatorOverride, this);
     
+    IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithFakerHub(Faker fakerHub) => WithFakerHub<IAutoGenerateConfigBuilder>(fakerHub, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithLocale(string locale) => WithLocale<IAutoGenerateConfigBuilder>(locale, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithRepeatCount(int count) => WithRepeatCount<IAutoGenerateConfigBuilder>(count, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithRecursiveDepth(int depth) => WithRecursiveDepth<IAutoGenerateConfigBuilder>(depth, this);
@@ -34,6 +37,7 @@ namespace AutoBogus
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithSkip<TType>(Expression<Func<TType, object>> member) => WithSkip<IAutoGenerateConfigBuilder, TType>(member, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithOverride(AutoGeneratorOverride generatorOverride) => WithOverride<IAutoGenerateConfigBuilder>(generatorOverride, this);
     
+    IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithFakerHub(Faker fakerHub) => WithFakerHub<IAutoFakerConfigBuilder>(fakerHub, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithLocale(string locale) => WithLocale<IAutoFakerConfigBuilder>(locale, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithRepeatCount(int count) => WithRepeatCount<IAutoFakerConfigBuilder>(count, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithRecursiveDepth(int depth) => WithRecursiveDepth<IAutoFakerConfigBuilder>(depth, this);
@@ -42,7 +46,13 @@ namespace AutoBogus
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithSkip<TType>(Expression<Func<TType, object>> member) => WithSkip<IAutoFakerConfigBuilder, TType>(member, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithOverride(AutoGeneratorOverride generatorOverride) => WithOverride<IAutoFakerConfigBuilder>(generatorOverride, this);
     IAutoFakerConfigBuilder IAutoFakerConfigBuilder.WithArgs(params object[] args) => WithArgs<IAutoFakerConfigBuilder>(args, this);
-    
+
+    internal TBuilder WithFakerHub<TBuilder>(Faker fakerHub, TBuilder builder)
+    {
+      Config.FakerHub = fakerHub;
+      return builder;
+    }
+
     internal TBuilder WithLocale<TBuilder>(string locale, TBuilder builder)
     {
       Config.Locale = locale ?? AutoConfig.DefaultLocale;

--- a/src/AutoBogus/AutoFaker[T].cs
+++ b/src/AutoBogus/AutoFaker[T].cs
@@ -63,6 +63,9 @@ namespace AutoBogus
       {
         _config = value;
 
+        if (_config.FakerHub != null)
+          FakerHub = _config.FakerHub;
+
         Locale = _config.Locale;
         Binder = _config.Binder;
 

--- a/src/AutoBogus/AutoGenerateContext.cs
+++ b/src/AutoBogus/AutoGenerateContext.cs
@@ -11,7 +11,7 @@ namespace AutoBogus
   public sealed class AutoGenerateContext
   {
     internal AutoGenerateContext(AutoConfig config)
-      : this(null, config)
+      : this(config.FakerHub, config)
     { }
 
     internal AutoGenerateContext(Faker faker, AutoConfig config)

--- a/src/AutoBogus/IAutoConfigBuilder.cs
+++ b/src/AutoBogus/IAutoConfigBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using Bogus;
 
 namespace AutoBogus
 {
@@ -9,6 +10,13 @@ namespace AutoBogus
   /// <typeparam name="TBuilder">The builder type.</typeparam>
   public interface IAutoConfigBuilder<TBuilder>
   {
+    /// <summary>
+    /// Registers the Faker hub to use in underlying calls to Bogus.
+    /// </summary>
+    /// <param name="fakerHub">The Faker object to use as the faker hub</param>
+    /// <returns>The current configuration builder instance.</returns>
+    TBuilder WithFakerHub(Faker fakerHub);
+
     /// <summary>
     /// Registers the locale to use when generating values.
     /// </summary>


### PR DESCRIPTION
In our project, we want the ability to use repeatable random seeds with bogus data. As far as I can tell, the underlying Bogus library supports this by using a common `FakerHub` across all `Faker` instances -- this "hub" can then have its `Randomizer` configured at any time, affecting all future generated data, and if `Randomizer` is repeatedly set to an object with the same seed, then the same sequence of calls to Bogus will produce the same sequence of bogus data.

This PR adds the ability to configure `AutoBogus` to inject a caller-supplied `Faker` in as the `FakerHub` for calls into the underlying `Bogus` layer.

Unit tests verify the new configuration builder functionality and the injection of the `FakerHub` value itself.