### PR TITLE
Added generators for DataSet and DataTable types (both typed and vanilla)

### DIFF
--- a/src/AutoBogus.Playground/AutoBogus.Playground.csproj
+++ b/src/AutoBogus.Playground/AutoBogus.Playground.csproj
@@ -22,6 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoBogus.Tests.NET45/AutoBogus.Tests.NET45.csproj
+++ b/src/AutoBogus.Tests.NET45/AutoBogus.Tests.NET45.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -60,6 +60,9 @@
     <Compile Include="..\AutoBogus.Tests\AutoGeneratorsFixture.cs">
       <Link>AutoGeneratorsFixture.cs</Link>
     </Compile>
+    <Compile Include="..\AutoBogus.Tests\AutoGeneratorsFixture.Data.cs">
+      <Link>AutoGeneratorsFixture.Data.cs</Link>
+    </Compile>
     <Compile Include="..\AutoBogus.Tests\FakeItEasyBinderFixture.cs">
       <Link>FakeItEasyBinderFixture.cs</Link>
     </Compile>
@@ -95,6 +98,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
@@ -106,6 +111,9 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="Validation, Version=2.4.0.0, Culture=neutral, PublicKeyToken=2fc06f0d701809a7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Validation.2.4.18\lib\net45\Validation.dll</HintPath>
+    </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -118,6 +126,9 @@
     </Reference>
     <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Xunit.SkippableFact, Version=1.4.0.0, Culture=neutral, PublicKeyToken=b2b52da82b58eb73, processorArchitecture=MSIL">
+      <HintPath>..\packages\Xunit.SkippableFact.1.4.13\lib\net452\Xunit.SkippableFact.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -162,7 +173,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.props'))" />
     <Error Condition="!Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.4.1\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.3\build\net452\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\packages\xunit.core.2.4.1\build\xunit.core.targets" Condition="Exists('..\packages\xunit.core.2.4.1\build\xunit.core.targets')" />
 </Project>

--- a/src/AutoBogus.Tests.NET45/app.config
+++ b/src/AutoBogus.Tests.NET45/app.config
@@ -14,6 +14,14 @@
         <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.4.1.0" newVersion="2.4.1.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/AutoBogus.Tests.NET45/packages.config
+++ b/src/AutoBogus.Tests.NET45/packages.config
@@ -6,9 +6,11 @@
   <package id="FluentAssertions" version="5.10.3" targetFramework="net452" />
   <package id="Moq" version="4.14.5" targetFramework="net452" />
   <package id="NSubstitute" version="4.2.2" targetFramework="net452" />
+  <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net452" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net452" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
+  <package id="Validation" version="2.4.18" targetFramework="net452" />
   <package id="xunit" version="2.4.1" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net452" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net452" />
@@ -17,4 +19,5 @@
   <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net452" />
   <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net452" />
   <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net452" developmentDependency="true" />
+  <package id="Xunit.SkippableFact" version="1.4.13" targetFramework="net452" />
 </packages>

--- a/src/AutoBogus.Tests/AutoBogus.Tests.csproj
+++ b/src/AutoBogus.Tests/AutoBogus.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
@@ -14,11 +14,13 @@
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="ReportGenerator" Version="4.6.7" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AutoBogus.Tests/AutoGeneratorsFixture.Data.cs
+++ b/src/AutoBogus.Tests/AutoGeneratorsFixture.Data.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+
+using AutoBogus.Generators;
+
+using FluentAssertions;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace AutoBogus.Tests
+{
+  partial class AutoGeneratorsFixture
+  {
+    public class DataSetGeneratorFacet
+      : AutoGeneratorsFixture
+    {
+      public static IEnumerable<object[]> GetTryCreateGeneratorTestCases()
+      {
+        yield return new object[] { typeof(DataSet), true };
+        yield return new object[] { typeof(TypedDataSet), true };
+        yield return new object[] { typeof(object), false };
+      }
+
+      [Theory]
+      [MemberData(nameof(GetTryCreateGeneratorTestCases))]
+      public void TryCreateGenerator_Should_Create_Generator(Type dataSetType, bool shouldSucceed)
+      {
+        // Act
+        bool success = DataSetGenerator.TryCreateGenerator(dataSetType, out var generator);
+
+        // Assert
+        if (shouldSucceed)
+        {
+          success.Should().BeTrue();
+          generator.Should().NotBeNull();
+        }
+        else
+          success.Should().BeFalse();
+      }
+
+      public static IEnumerable<object[]> GetGenerateTestCases()
+      {
+        yield return new object[] { typeof(DataSet) };
+        yield return new object[] { typeof(TypedDataSet) };
+      }
+
+      [SkippableTheory]
+      [MemberData(nameof(GetGenerateTestCases))]
+      public void Generate_Should_Return_DataSet(Type dataSetType)
+      {
+        // Arrange
+        var context = CreateContext(dataSetType);
+
+        bool success = DataSetGenerator.TryCreateGenerator(context.GenerateType, out var generator);
+
+        Skip.IfNot(success, $"couldn't create generator for {dataSetType.Name}");
+
+        // Act
+        var result = generator.Generate(context);
+
+        // Assert
+        result.Should().BeOfType(dataSetType);
+
+        var dataSet = (DataSet)result;
+
+        dataSet.Tables.Should().NotBeEmpty();
+
+        foreach (var table in dataSet.Tables.OfType<DataTable>())
+        {
+          table.Columns.Should().NotBeEmpty();
+          table.Rows.Should().NotBeEmpty();
+        }
+      }
+
+      internal class TypedDataSet : DataSet
+      {
+        public TypedDataSet()
+        {
+          Tables.Add(new DataTableGeneratorFacet.TypedDataTable1());
+          Tables.Add(new DataTableGeneratorFacet.TypedDataTable2());
+        }
+      }
+    }
+
+    public class DataTableGeneratorFacet
+      : AutoGeneratorsFixture
+    {
+      public static IEnumerable<object[]> GetTryCreateGeneratorTestCases()
+      {
+        yield return new object[] { typeof(DataTable), true };
+        yield return new object[] { typeof(TypedDataTable1), true };
+        yield return new object[] { typeof(TypedDataTable2), true };
+        yield return new object[] { typeof(object), false };
+      }
+
+      [Theory]
+      [MemberData(nameof(GetTryCreateGeneratorTestCases))]
+      public void TryCreateGenerator_Should_Create_Generator(Type dataTableType, bool shouldSucceed)
+      {
+        // Act
+        bool success = DataTableGenerator.TryCreateGenerator(dataTableType, out var generator);
+
+        // Assert
+        if (shouldSucceed)
+        {
+          success.Should().BeTrue();
+          generator.Should().NotBeNull();
+        }
+        else
+          success.Should().BeFalse();
+      }
+
+      public static IEnumerable<object[]> GetGenerateTestCases()
+      {
+        yield return new object[] { typeof(DataTable) };
+        yield return new object[] { typeof(TypedDataTable1) };
+        yield return new object[] { typeof(TypedDataTable2) };
+      }
+
+      [SkippableTheory]
+      [MemberData(nameof(GetGenerateTestCases))]
+      public void Generate_Should_Return_DataTable(Type dataTableType)
+      {
+        // Arrange
+        var context = CreateContext(dataTableType);
+
+        bool success = DataTableGenerator.TryCreateGenerator(context.GenerateType, out var generator);
+
+        Skip.IfNot(success, $"couldn't create generator for {dataTableType.Name}");
+
+        // Act
+        var result = generator.Generate(context);
+
+        // Assert
+        result.Should().BeOfType(dataTableType);
+
+        var dataTable = (DataTable)result;
+
+        dataTable.Columns.Should().NotBeEmpty();
+        dataTable.Rows.Should().NotBeEmpty();
+      }
+
+      internal class TypedDataTable1 : TypedTableBase<TypedDataRow1>
+      {
+        public TypedDataTable1()
+        {
+          TableName = "TypedDataTable1";
+
+          Columns.Add(new DataColumn("RecordID", typeof(int)));
+          Columns.Add(new DataColumn("BoolColumn", typeof(bool)));
+          Columns.Add(new DataColumn("CharColumn", typeof(char)));
+          Columns.Add(new DataColumn("SignedByteColumn", typeof(sbyte)));
+          Columns.Add(new DataColumn("ByteColumn", typeof(byte)));
+          Columns.Add(new DataColumn("ShortColumn", typeof(short)));
+          Columns.Add(new DataColumn("UnsignedShortColumn", typeof(ushort)));
+          Columns.Add(new DataColumn("IntColumn", typeof(int)));
+          Columns.Add(new DataColumn("GuidColumn", typeof(Guid)));
+        }
+      }
+
+      internal class TypedDataRow1 : DataRow
+      {
+        public TypedDataRow1(DataRowBuilder builder)
+          : base(builder)
+        {
+        }
+      }
+
+      internal class TypedDataTable2 : TypedTableBase<TypedDataRow2>
+      {
+        public TypedDataTable2()
+        {
+          TableName = "TypedDataTable2";
+
+          Columns.Add(new DataColumn("RecordID", typeof(int)));
+          Columns.Add(new DataColumn("IntColumn", typeof(int)));
+          Columns.Add(new DataColumn("UnsignedIntColumn", typeof(uint)));
+          Columns.Add(new DataColumn("LongColumn", typeof(long)));
+          Columns.Add(new DataColumn("UnsignedLongColumn", typeof(ulong)));
+          Columns.Add(new DataColumn("SingleColumn", typeof(float)));
+          Columns.Add(new DataColumn("DoubleColumn", typeof(double)));
+          Columns.Add(new DataColumn("DecimalColumn", typeof(decimal)));
+          Columns.Add(new DataColumn("DateTimeColumn", typeof(DateTime)));
+          Columns.Add(new DataColumn("TimeSpanColumn", typeof(TimeSpan)));
+          Columns.Add(new DataColumn("StringColumn", typeof(string)));
+        }
+      }
+
+      internal class TypedDataRow2 : DataRow
+      {
+        public TypedDataRow2(DataRowBuilder builder)
+          : base(builder)
+        {
+        }
+      }
+    }
+
+    static internal Type ResolveType(string fullTypeName, bool throwOnError)
+    {
+      foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        if (assembly.GetType(fullTypeName) is Type type)
+          return type;
+
+      if (throwOnError)
+        throw new XunitException($"Unable to resolve type: {fullTypeName}");
+
+      return null;
+    }
+  }
+}

--- a/src/AutoBogus.Tests/AutoGeneratorsFixture.cs
+++ b/src/AutoBogus.Tests/AutoGeneratorsFixture.cs
@@ -65,6 +65,29 @@ namespace AutoBogus.Tests
           g.Key
         });
       }
+
+      [Theory]
+      [MemberData(nameof(GetDataSetAndDataTableTypes))]
+      public void GetGenerator_Should_Return_Generator_For_DataSets_And_DataTables(Type dataType, Type generatorType)
+      {
+        // Arrange
+        var context = CreateContext(dataType);
+
+        // Act
+        var generator = AutoGeneratorFactory.GetGenerator(context);
+
+        // Assert
+        generator.Should().BeAssignableTo(generatorType);
+      }
+
+      public static IEnumerable<object[]> GetDataSetAndDataTableTypes()
+      {
+        yield return new object[] { typeof(System.Data.DataSet), typeof(DataSetGenerator) };
+        yield return new object[] { typeof(DataSetGeneratorFacet.TypedDataSet), typeof(DataSetGenerator) };
+        yield return new object[] { typeof(System.Data.DataTable), typeof(DataTableGenerator) };
+        yield return new object[] { typeof(DataTableGeneratorFacet.TypedDataTable1), typeof(DataTableGenerator) };
+        yield return new object[] { typeof(DataTableGeneratorFacet.TypedDataTable2), typeof(DataTableGenerator) };
+      }
     }
 
     public class ExpandoObjectGenerator

--- a/src/AutoBogus/AutoBogus.csproj
+++ b/src/AutoBogus/AutoBogus.csproj
@@ -46,5 +46,15 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Data.DataSetExtensions">
+      <Version>4.5.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
+    <Reference Include="System.Data.DataSetExtensions" />
+  </ItemGroup>
+
 </Project>
 

--- a/src/AutoBogus/AutoGeneratorFactory.cs
+++ b/src/AutoBogus/AutoGeneratorFactory.cs
@@ -69,6 +69,18 @@ namespace AutoBogus
         return CreateGenericGenerator(typeof(ArrayGenerator<>), type);
       }
 
+#if !NETSTANDARD1_3
+      if (DataTableGenerator.TryCreateGenerator(type, out var dataTableGenerator))
+      {
+        return dataTableGenerator;
+      }
+
+      if (DataSetGenerator.TryCreateGenerator(type, out var dataSetGenerator))
+      {
+        return dataSetGenerator;
+      }
+#endif
+
       if (ReflectionHelper.IsEnum(type))
       {
         return CreateGenericGenerator(typeof(EnumGenerator<>), type);

--- a/src/AutoBogus/Generators/DataSetGenerator.cs
+++ b/src/AutoBogus/Generators/DataSetGenerator.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Data;
+using System.Linq;
+
+namespace AutoBogus.Generators
+{
+#if !NETSTANDARD1_3
+  internal abstract class DataSetGenerator
+    : IAutoGenerator
+  {
+    public static bool TryCreateGenerator(Type dataSetType, out DataSetGenerator generator)
+    {
+      generator = default;
+
+      if (dataSetType == typeof(DataSet))
+        generator = new UntypedDataSetGenerator();
+      else if (typeof(DataSet).IsAssignableFrom(dataSetType))
+        generator = new TypedDataSetGenerator(dataSetType);
+
+      return (generator != null);
+    }
+
+    public abstract object Generate(AutoGenerateContext context);
+
+    class UntypedDataSetGenerator : DataSetGenerator
+    {
+      public override object Generate(AutoGenerateContext context)
+      {
+        var dataSet = new DataSet();
+
+        if (!DataTableGenerator.TryCreateGenerator(typeof(DataTable), out var tableGenerator))
+          throw new Exception("Internal error: Couldn't create generator for DataTable");
+
+        for (int tableCount = context.Faker.Random.Int(2, 6); tableCount > 0; tableCount--)
+          dataSet.Tables.Add((DataTable)tableGenerator.Generate(context));
+
+        return dataSet;
+      }
+    }
+
+    class TypedDataSetGenerator : DataSetGenerator
+    {
+      Type _dataSetType;
+
+      public TypedDataSetGenerator(Type dataSetType)
+      {
+        _dataSetType = dataSetType;
+      }
+
+      public override object Generate(AutoGenerateContext context)
+      {
+        var dataSet = (DataSet)Activator.CreateInstance(_dataSetType);
+
+        foreach (var table in dataSet.Tables.OfType<DataTable>())
+        {
+          if (!DataTableGenerator.TryCreateGenerator(table.GetType(), out var tableGenerator))
+            throw new Exception($"Couldn't create generator for typed table type {table.GetType()}");
+
+          tableGenerator.PopulateRows(table, context);
+        }
+
+        return dataSet;
+      }
+    }
+  }
+#endif
+}

--- a/src/AutoBogus/Generators/DataTableGenerator.cs
+++ b/src/AutoBogus/Generators/DataTableGenerator.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Data;
+using System.Linq;
+using System.Threading;
+
+namespace AutoBogus.Generators
+{
+#if !NETSTANDARD1_3
+  internal abstract class DataTableGenerator
+    : IAutoGenerator
+  {
+    public static bool IsTypedDataTableType(Type type, out Type rowType)
+    {
+      rowType = default;
+
+      while (type != null)
+      {
+        if (type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(TypedTableBase<>)))
+        {
+          rowType = type.GetGenericArguments()[0];
+          return true;
+        }
+
+        type = type.BaseType;
+      }
+
+      return false;
+    }
+
+    public static bool TryCreateGenerator(Type tableType, out DataTableGenerator generator)
+    {
+      generator = default;
+
+      if (tableType == typeof(DataTable))
+        generator = new UntypedDataTableGenerator();
+      else if (IsTypedDataTableType(tableType, out var rowType))
+      {
+        var generatorType = typeof(TypedDataTableGenerator<,>).MakeGenericType(tableType, rowType);
+
+        generator = (DataTableGenerator)Activator.CreateInstance(generatorType);
+      }
+
+      return (generator != null);
+    }
+
+    public object Generate(AutoGenerateContext context)
+    {
+      var table = CreateTable(context);
+
+      PopulateRows(table, context);
+
+      return table;
+    }
+
+    public void PopulateRows(DataTable table, AutoGenerateContext context)
+    {
+      for (int rowCount = context.Faker.Random.Number(1, 20); rowCount > 0; rowCount--)
+      {
+        object[] columnValues = new object[table.Columns.Count];
+
+        for (int i = 0; i < table.Columns.Count; i++)
+          columnValues[i] = GenerateColumnValue(table.Columns[i], context);
+
+        table.Rows.Add(columnValues);
+      }
+    }
+
+    private object GenerateColumnValue(DataColumn dataColumn, AutoGenerateContext context)
+    {
+      switch (Type.GetTypeCode(dataColumn.DataType))
+      {
+        case TypeCode.Empty:
+        case TypeCode.DBNull: return null;
+        case TypeCode.Boolean: return context.Faker.Random.Bool();
+        case TypeCode.Char: return context.Faker.Lorem.Letter().Single();
+        case TypeCode.SByte: return context.Faker.Random.SByte();
+        case TypeCode.Byte: return context.Faker.Random.Byte();
+        case TypeCode.Int16: return context.Faker.Random.Short();
+        case TypeCode.UInt16: return context.Faker.Random.UShort();
+        case TypeCode.Int32:
+        {
+          if (dataColumn.ColumnName.EndsWith("ID", StringComparison.OrdinalIgnoreCase))
+            return Interlocked.Increment(ref context.Faker.IndexFaker);
+          else
+            return context.Faker.Random.Int();
+        }
+        case TypeCode.UInt32: return context.Faker.Random.UInt();
+        case TypeCode.Int64: return context.Faker.Random.Long();
+        case TypeCode.UInt64: return context.Faker.Random.ULong();
+        case TypeCode.Single: return context.Faker.Random.Float();
+        case TypeCode.Double: return context.Faker.Random.Double();
+        case TypeCode.Decimal: return context.Faker.Random.Decimal();
+        case TypeCode.DateTime: return context.Faker.Date.Between(DateTime.UtcNow.AddDays(-30), DateTime.UtcNow.AddDays(+30));
+        case TypeCode.String: return context.Faker.Lorem.Lines(1);
+
+        default:
+          if (dataColumn.DataType == typeof(TimeSpan))
+            return context.Faker.Date.Future() - context.Faker.Date.Future();
+          else if (dataColumn.DataType == typeof(Guid))
+            return context.Faker.Random.Guid();
+          else
+          {
+            var proxy = (Proxy)Activator.CreateInstance(typeof(Proxy<>).MakeGenericType(dataColumn.DataType));
+
+            return proxy.Generate(context);
+          }
+      }
+    }
+
+    abstract class Proxy
+    {
+      public abstract object Generate(AutoGenerateContext context);
+    }
+
+    class Proxy<T>
+      : Proxy
+      where T : class
+    {
+      public override object Generate(AutoGenerateContext context)
+        => context.Generate<T>();
+    }
+
+    protected abstract DataTable CreateTable(AutoGenerateContext context);
+
+    class UntypedDataTableGenerator
+      : DataTableGenerator
+    {
+      protected override DataTable CreateTable(AutoGenerateContext context)
+      {
+        var table = new DataTable();
+
+        for (int i = context.Faker.Random.Int(3, 10); i >= 0; i--)
+        {
+          table.Columns.Add(
+            new DataColumn()
+            {
+              ColumnName = context.Faker.Database.Column() + i,
+              DataType = Type.GetType("System." + context.Faker.PickRandom(
+                ((TypeCode[])Enum.GetValues(typeof(TypeCode)))
+                .Except(new[] { TypeCode.Empty, TypeCode.Object, TypeCode.DBNull })
+                .ToArray())),
+            });
+        }
+
+        return table;
+      }
+    }
+
+    class TypedDataTableGenerator<TTable, TRow>
+      : DataTableGenerator
+      where TTable : DataTable, new()
+    {
+      protected override DataTable CreateTable(AutoGenerateContext context)
+        => new TTable();
+    }
+  }
+#endif
+}


### PR DESCRIPTION
This PR:

* Adds generator types `DataSetGenerator` and DataTableGenerator`. These contain code both for vanilla `DataSet` and `DataTable` and for typed `DataSet` and `DataTable` objects.
* Updates `AutoGeneratorFactory.ResolveGenerator` to tie these in for the types they support.
* Adds necessary references to the projects in the solution. In AutoBogus.csproj, a regular reference to the system library is used for the net40 build target framework, a package reference is used for the netstandard2.0 target framework, and the code is `#if`ed out for the netstandard1.3 target framework.
* Adds unit tests for the new functionality.
* Fixes a bug in AutoBogus.Tests.NET45.csproj that was preventing it from running tests successfully. Its `packages.config` referenced `xunit.runner.visualstudio` version 2.4.1, but for some reason the .csproj had `<Import>` and `<Error>` lines referencing version 2.4.3 of that package, which did not exist in my `packages` cache folder.

The net result of this should be that `AutoFaker.Generate<MyDataTableType>()` should be able to create an instance of the typed `DataTable` and populate it with bogus data. I would like to use `AutoBogus` in a context where there are a bunch of auto-generated typed `DataTable` types.