### PR TITLE
Fixed AutoFaker<T>.Generate populating the properties of a generated object twice

### DIFF
--- a/src/AutoBogus.Tests.Models/Simple/TestClassWithSingleProperty.cs
+++ b/src/AutoBogus.Tests.Models/Simple/TestClassWithSingleProperty.cs
@@ -1,0 +1,7 @@
+namespace AutoBogus.Tests.Models.Simple
+{
+  public class TestClassWithSingleProperty<T>
+  {
+    public T Value;
+  }
+}

--- a/src/AutoBogus.Tests/AutoFakerFixture.cs
+++ b/src/AutoBogus.Tests/AutoFakerFixture.cs
@@ -299,6 +299,29 @@ namespace AutoBogus.Tests
         order.Should().BeGeneratedWithoutMocks();
         instance.Should().Be(order);
       }
+
+      [Fact]
+      public void Should_Not_Initialize_Properties_Twice()
+      {
+        // Arrange
+        var random1 = new Randomizer(12345);
+        var random2 = new Randomizer(12345);
+
+        var faker = new Faker() { Random = random1 };
+
+        var autoFaker = new AutoFaker<TestClassWithSingleProperty<int>>();
+
+        autoFaker.Configure(
+          builder => builder.WithFakerHub(faker));
+
+        // Act
+        var instance = autoFaker.Generate(); // Should pull one int from random1
+
+        var expectedValue = random2.Int();
+
+        // Assert
+        instance.Value.Should().Be(expectedValue);
+      }
     }
 
     public class AutoFaker_WithFakerHub

--- a/src/AutoBogus/AutoFaker[T].cs
+++ b/src/AutoBogus/AutoFaker[T].cs
@@ -207,9 +207,9 @@ namespace AutoBogus
               }
             }
 
-            // Get the type generator
-            var generator = AutoGeneratorFactory.GetGenerator(context);
-            return (TType)generator.Generate(context);
+            // Create a blank instance. It will be populated in the FinalizeAction registered
+            // by PrepareFinish (context.Binder.PopulateInstance<TType>).
+            return context.Binder.CreateInstance<TType>(context);
           }
 
           return DefaultCreateAction.Invoke(faker);


### PR DESCRIPTION
When making a quick test app to prove the use of `WithFakerHub`, I discovered a bug: The `AutoFaker<T>` class, when generating instances of `T`, initializes them with bogus data twice.

This is because in the `Generate` method, it sets up a `CreateAction`, and that `CreateAction`, whose job it is to produce an actual instance of `T`, does so by calling `AutoGeneratorFactory.GetGenerator(context).Generate(context)`. The resulting `T` has its members initialized already -- but, a separate `FinalizeAction` is also registered, which overwrites whatever is already in the object, and the underlying `Faker` calls this via its `PopulateInternal` method before returning:
```
         // Faker[T].cs line 458:
         var instance = createRule(this.FakerHub);

         PopulateInternal(instance, cleanRules);

         return instance;
```
When the non-generic `AutoFaker`'s `Generate<TType>` method is being used, it does not use `Faker.Generate<TType>` at all; instead, it goes directly to `AutoBogus`'s `AutoBinder` and calls `CreateInstance<TType>` followed by `PopulateInstance<TType>`. This `CreateInstance<TType>` call does not fill the object with bogus data, so it only gets populated once.

The `Binder.PopulateInstance<TType>` is the same action that the `FinalizeAction` in `AutoBogus<T>` takes to populate the object, so I believe the correct thing for the `CreateAction` to be doing is `Binder.CreateInstance<TType>`. This makes the `AutoFaker<T>.Generate` flow parallel the actions that `TypeGenerator` takes when `AutoFaker.Generate<TType>` is used.

This PR adds a unit test that fails when the erroneous behaviour occurs, and makes this small change to the `CreateAction` used by `AutoFaker<T>` to fix the failing test.