### PR TITLE
Link to NuGet package itself from NuGet images in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Nuget](https://img.shields.io/nuget/v/AutoBogus?style=for-the-badge)
-![Nuget](https://img.shields.io/nuget/dt/AutoBogus?style=for-the-badge)
+[![NuGet](https://img.shields.io/nuget/v/AutoBogus?style=for-the-badge)](https://www.nuget.org/packages/AutoBogus/)
+[![NuGet](https://img.shields.io/nuget/dt/AutoBogus?style=for-the-badge)](https://www.nuget.org/packages/AutoBogus/)
 
 # AutoBogus
 A C# library complementing the [Bogus](https://github.com/bchavez/Bogus) generator by adding auto creation and population capabilities.


### PR DESCRIPTION
README.md has images at the top that show shields for the current deployed version and download count for the AutoBogus NuGet package. Clicking on these, though, just goes to the image itself. This PR updates these images so that they link to the NuGet package page.