### PR TITLE
Add support for overriding the number of generated rows in DataTables

### DIFF
--- a/src/AutoBogus.Tests/AutoGeneratorsFixture.cs
+++ b/src/AutoBogus.Tests/AutoGeneratorsFixture.cs
@@ -458,7 +458,7 @@ namespace AutoBogus.Tests
       return (IAutoGenerator)Activator.CreateInstance(type);
     }
 
-    private AutoGenerateContext CreateContext(Type type, IList<AutoGeneratorOverride> generatorOverrides = null)
+    private AutoGenerateContext CreateContext(Type type, IList<AutoGeneratorOverride> generatorOverrides = null, Func<AutoGenerateContext, int> dataTableRowCountFunctor = null)
     {
       var faker = new Faker();
       var config = new AutoConfig();
@@ -466,6 +466,11 @@ namespace AutoBogus.Tests
       if (generatorOverrides != null)
       {
         config.Overrides = generatorOverrides;
+      }
+
+      if (dataTableRowCountFunctor != null)
+      {
+        config.DataTableRowCount = dataTableRowCountFunctor;
       }
 
       return new AutoGenerateContext(faker, config)

--- a/src/AutoBogus/AutoBogus.xml
+++ b/src/AutoBogus/AutoBogus.xml
@@ -570,6 +570,20 @@
             <param name="count">The repeat count to use.</param>
             <returns>The current configuration builder instance.</returns>
         </member>
+        <member name="M:AutoBogus.IAutoConfigBuilder`1.WithDataTableRowCount(System.Int32)">
+            <summary>
+            Registers the number of rows to generate in a <see cref="T:System.Data.DataTable"/>.
+            </summary>
+            <param name="count">The row count to use.</param>
+            <returns>The current configuration builder instance.</returns>
+        </member>
+        <member name="M:AutoBogus.IAutoConfigBuilder`1.WithDataTableRowCount(System.Func{AutoBogus.AutoGenerateContext,System.Int32})">
+            <summary>
+            Registers the number of rows to generate in a <see cref="T:System.Data.DataTable"/>.
+            </summary>
+            <param name="count">The row count to use.</param>
+            <returns>The current configuration builder instance.</returns>
+        </member>
         <member name="M:AutoBogus.IAutoConfigBuilder`1.WithRecursiveDepth(System.Int32)">
             <summary>
             Registers the depth to recursively generate.

--- a/src/AutoBogus/AutoConfig.cs
+++ b/src/AutoBogus/AutoConfig.cs
@@ -11,12 +11,14 @@ namespace AutoBogus
     internal const int GenerateAttemptsThreshold = 3;
 
     internal static readonly Func<AutoGenerateContext, int> DefaultRepeatCount = context => 3;
+    internal static readonly Func<AutoGenerateContext, int> DefaultDataTableRowCount = context => 15;
     internal static readonly Func<AutoGenerateContext, int> DefaultRecursiveDepth = context => 2;
 
     internal AutoConfig()
     {
       Locale = DefaultLocale;
       RepeatCount = DefaultRepeatCount;
+      DataTableRowCount = DefaultDataTableRowCount;
       RecursiveDepth = DefaultRecursiveDepth;
       Binder = new AutoBinder();
       SkipTypes = new List<Type>();
@@ -28,6 +30,7 @@ namespace AutoBogus
     {
       Locale = config.Locale;
       RepeatCount = config.RepeatCount;
+      DataTableRowCount = config.DataTableRowCount;
       RecursiveDepth = config.RecursiveDepth;
       Binder = config.Binder;
       FakerHub = config.FakerHub;
@@ -38,6 +41,7 @@ namespace AutoBogus
 
     internal string Locale { get; set; }
     internal Func<AutoGenerateContext, int> RepeatCount { get; set; }
+    internal Func<AutoGenerateContext, int> DataTableRowCount { get; set; }
     internal Func<AutoGenerateContext, int> RecursiveDepth { get; set; }
     internal IAutoBinder Binder { get; set; }
     internal Faker FakerHub { get; set; }

--- a/src/AutoBogus/AutoConfigBuilder.cs
+++ b/src/AutoBogus/AutoConfigBuilder.cs
@@ -19,6 +19,8 @@ namespace AutoBogus
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithLocale(string locale) => WithLocale<IAutoFakerDefaultConfigBuilder>(locale, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithRepeatCount(int count) => WithRepeatCount<IAutoFakerDefaultConfigBuilder>(context => count, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithRepeatCount(Func<AutoGenerateContext, int> count) => WithRepeatCount<IAutoFakerDefaultConfigBuilder>(count, this);
+    IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithDataTableRowCount(int count) => WithDataTableRowCount<IAutoFakerDefaultConfigBuilder>(context => count, this);
+    IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithDataTableRowCount(Func<AutoGenerateContext, int> count) => WithDataTableRowCount<IAutoFakerDefaultConfigBuilder>(count, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithRecursiveDepth(int depth) => WithRecursiveDepth<IAutoFakerDefaultConfigBuilder>(context => depth, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithRecursiveDepth(Func<AutoGenerateContext, int> depth) => WithRecursiveDepth<IAutoFakerDefaultConfigBuilder>(depth, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithBinder(IAutoBinder binder) => WithBinder<IAutoFakerDefaultConfigBuilder>(binder, this);
@@ -30,6 +32,8 @@ namespace AutoBogus
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithLocale(string locale) => WithLocale<IAutoGenerateConfigBuilder>(locale, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithRepeatCount(int count) => WithRepeatCount<IAutoGenerateConfigBuilder>(context => count, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithRepeatCount(Func<AutoGenerateContext, int> count) => WithRepeatCount<IAutoGenerateConfigBuilder>(count, this);
+    IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithDataTableRowCount(int count) => WithDataTableRowCount<IAutoGenerateConfigBuilder>(context => count, this);
+    IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithDataTableRowCount(Func<AutoGenerateContext, int> count) => WithDataTableRowCount<IAutoGenerateConfigBuilder>(count, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithRecursiveDepth(int depth) => WithRecursiveDepth<IAutoGenerateConfigBuilder>(context => depth, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithRecursiveDepth(Func<AutoGenerateContext, int> depth) => WithRecursiveDepth<IAutoGenerateConfigBuilder>(depth, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithBinder(IAutoBinder binder) => WithBinder<IAutoGenerateConfigBuilder>(binder, this);
@@ -41,6 +45,8 @@ namespace AutoBogus
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithLocale(string locale) => WithLocale<IAutoFakerConfigBuilder>(locale, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithRepeatCount(int count) => WithRepeatCount<IAutoFakerConfigBuilder>(context => count, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithRepeatCount(Func<AutoGenerateContext, int> count) => WithRepeatCount<IAutoFakerConfigBuilder>(count, this);
+    IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithDataTableRowCount(int count) => WithDataTableRowCount<IAutoFakerConfigBuilder>(context => count, this);
+    IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithDataTableRowCount(Func<AutoGenerateContext, int> count) => WithDataTableRowCount<IAutoFakerConfigBuilder>(count, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithRecursiveDepth(int depth) => WithRecursiveDepth<IAutoFakerConfigBuilder>(context => depth, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithRecursiveDepth(Func<AutoGenerateContext, int> depth) => WithRecursiveDepth<IAutoFakerConfigBuilder>(depth, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithBinder(IAutoBinder binder) => WithBinder<IAutoFakerConfigBuilder>(binder, this);
@@ -59,6 +65,12 @@ namespace AutoBogus
     internal TBuilder WithRepeatCount<TBuilder>(Func<AutoGenerateContext, int> count, TBuilder builder)
     {
       Config.RepeatCount = count ?? AutoConfig.DefaultRepeatCount;
+      return builder;
+    }
+
+    internal TBuilder WithDataTableRowCount<TBuilder>(Func<AutoGenerateContext, int> count, TBuilder builder)
+    {
+      Config.DataTableRowCount = count ?? AutoConfig.DefaultDataTableRowCount;
       return builder;
     }
 

--- a/src/AutoBogus/Generators/DataSetGenerator.cs
+++ b/src/AutoBogus/Generators/DataSetGenerator.cs
@@ -56,6 +56,8 @@ namespace AutoBogus.Generators
           if (!DataTableGenerator.TryCreateGenerator(table.GetType(), out var tableGenerator))
             throw new Exception($"Couldn't create generator for typed table type {table.GetType()}");
 
+          context.Instance = table;
+
           tableGenerator.PopulateRows(table, context);
         }
 

--- a/src/AutoBogus/Generators/DataTableGenerator.cs
+++ b/src/AutoBogus/Generators/DataTableGenerator.cs
@@ -47,6 +47,8 @@ namespace AutoBogus.Generators
     {
       var table = CreateTable(context);
 
+      context.Instance = table;
+
       PopulateRows(table, context);
 
       return table;
@@ -54,7 +56,15 @@ namespace AutoBogus.Generators
 
     public void PopulateRows(DataTable table, AutoGenerateContext context)
     {
-      for (int rowCount = context.Faker.Random.Number(1, 20); rowCount > 0; rowCount--)
+      int rowCount = -1;
+
+      if (context.Config.DataTableRowCount != null)
+        rowCount = context.Config.DataTableRowCount(context);
+
+      if (rowCount < 0)
+        rowCount = context.Faker.Random.Number(1, 20);
+
+      while (rowCount > 0)
       {
         object[] columnValues = new object[table.Columns.Count];
 
@@ -62,6 +72,8 @@ namespace AutoBogus.Generators
           columnValues[i] = GenerateColumnValue(table.Columns[i], context);
 
         table.Rows.Add(columnValues);
+
+        rowCount--;
       }
     }
 

--- a/src/AutoBogus/IAutoConfigBuilder.cs
+++ b/src/AutoBogus/IAutoConfigBuilder.cs
@@ -32,6 +32,20 @@ namespace AutoBogus
     TBuilder WithRepeatCount(Func<AutoGenerateContext, int> count);
 
     /// <summary>
+    /// Registers the number of rows to generate in a <see cref="System.Data.DataTable"/>.
+    /// </summary>
+    /// <param name="count">The row count to use.</param>
+    /// <returns>The current configuration builder instance.</returns>
+    TBuilder WithDataTableRowCount(int count);
+
+    /// <summary>
+    /// Registers the number of rows to generate in a <see cref="System.Data.DataTable"/>.
+    /// </summary>
+    /// <param name="count">The row count to use.</param>
+    /// <returns>The current configuration builder instance.</returns>
+    TBuilder WithDataTableRowCount(Func<AutoGenerateContext, int> count);
+
+    /// <summary>
     /// Registers the depth to recursively generate.
     /// </summary>
     /// <param name="depth">The recursive depth to use.</param>


### PR DESCRIPTION
This PR:

- Adds new configuration method `.WithDataTableRowCount` to the config builder interface.
- Implements it in the config object.
- Adds unit tests that can only pass when it is properly implemented.
- Updates the `DataTable` and `DataSet` generators to implement it, making the tests pass.
- Includes a corresponding update to the documented API surface in `AutoBogus.xml`.