### PR TITLE
Add support for derived generic collection types

### DIFF
--- a/src/AutoBogus.Tests/AutoGeneratorsFixture.cs
+++ b/src/AutoBogus.Tests/AutoGeneratorsFixture.cs
@@ -14,6 +14,219 @@ namespace AutoBogus.Tests
 {
   public partial class AutoGeneratorsFixture
   {
+    public class Factory
+    {
+      public class ReadOnlyDictionary
+      {
+        public class ReadOnlyDictionaryBase<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>
+        {
+          public ReadOnlyDictionaryBase(IEnumerable<KeyValuePair<TKey, TValue>> items)
+          {
+            foreach (var item in items)
+              _store[item.Key] = item.Value;
+          }
+
+          Dictionary<TKey, TValue> _store = new Dictionary<TKey, TValue>();
+
+          public TValue this[TKey key] => _store[key];
+          public IEnumerable<TKey> Keys => _store.Keys;
+          public IEnumerable<TValue> Values => _store.Values;
+          public int Count => _store.Count;
+
+          public bool ContainsKey(TKey key) => _store.ContainsKey(key);
+          public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _store.GetEnumerator();
+          public bool TryGetValue(TKey key, out TValue value) => _store.TryGetValue(key, out value);
+          IEnumerator IEnumerable.GetEnumerator() => _store.GetEnumerator();
+        }
+
+        public class NonGeneric : ReadOnlyDictionaryBase<int, string>
+        {
+          public NonGeneric(IEnumerable<KeyValuePair<int, string>> items) : base(items)
+          {
+          }
+        }
+
+        public class OneArgument<T> : ReadOnlyDictionaryBase<T, string>
+        {
+          public OneArgument(IEnumerable<KeyValuePair<T, string>> items) : base(items)
+          {
+          }
+        }
+
+        public class TwoArgumentsThatAreDifferentFromBaseReadOnlyDictionaryClass<TValue, TKey> : ReadOnlyDictionaryBase<TKey, TValue>
+        {
+          public TwoArgumentsThatAreDifferentFromBaseReadOnlyDictionaryClass(IEnumerable<KeyValuePair<TKey, TValue>> items) : base(items)
+          {
+          }
+        }
+
+        public static IEnumerable<object[]> ListOfReadOnlyDictionaryTypes
+        {
+          get
+          {
+            yield return new[] { typeof(NonGeneric) };
+            yield return new[] { typeof(OneArgument<int>) };
+            yield return new[] { typeof(TwoArgumentsThatAreDifferentFromBaseReadOnlyDictionaryClass<string, int>) };
+          }
+        }
+
+        [Theory]
+        [MemberData(nameof(ListOfReadOnlyDictionaryTypes))]
+        public void Should_Handle_Subclasses(Type readOnlyDictionaryType)
+        {
+          // Arrange
+          var config = new AutoConfig();
+
+          var context = new AutoGenerateContext(config);
+
+          context.GenerateType = readOnlyDictionaryType;
+
+          // Act
+          var generator = AutoGeneratorFactory.ResolveGenerator(context);
+
+          var instance = generator.Generate(context);
+
+          // Arrange
+          generator.Should().BeOfType<ReadOnlyDictionaryGenerator<int, string>>();
+
+          instance.Should().BeOfType(readOnlyDictionaryType);
+        }
+      }
+
+      public class Dictionary
+      {
+        public class NonGeneric : Dictionary<int, string>
+        {
+        }
+
+        public class OneArgument<T> : Dictionary<T, string>
+        {
+        }
+
+        public class TwoArgumentsThatAreDifferentFromBaseDictionaryClass<TValue, TKey> : Dictionary<TKey, TValue>
+        {
+        }
+
+        public static IEnumerable<object[]> ListOfDictionaryTypes
+        {
+          get
+          {
+            yield return new[] { typeof(NonGeneric) };
+            yield return new[] { typeof(OneArgument<int>) };
+            yield return new[] { typeof(TwoArgumentsThatAreDifferentFromBaseDictionaryClass<string, int>) };
+          }
+        }
+
+        [Theory]
+        [MemberData(nameof(ListOfDictionaryTypes))]
+        public void Should_Handle_Subclasses(Type dictionaryType)
+        {
+          // Arrange
+          var config = new AutoConfig();
+
+          var context = new AutoGenerateContext(config);
+
+          context.GenerateType = dictionaryType;
+
+          // Act
+          var generator = AutoGeneratorFactory.ResolveGenerator(context);
+
+          var instance = generator.Generate(context);
+
+          // Arrange
+          generator.Should().BeOfType<DictionaryGenerator<int, string>>();
+
+          instance.Should().BeOfType(dictionaryType);
+        }
+      }
+
+      public class Set
+      {
+        public class NonGeneric : HashSet<int>
+        {
+        }
+
+        public class GenericWithDifferentType<TType> : HashSet<int>
+        {
+          public TType Property { get; set; }
+        }
+
+        public static IEnumerable<object[]> ListOfSetTypes
+        {
+          get
+          {
+            yield return new[] { typeof(NonGeneric) };
+            yield return new[] { typeof(GenericWithDifferentType<string>) };
+          }
+        }
+
+        [Theory]
+        [MemberData(nameof(ListOfSetTypes))]
+        public void Should_Handle_Subclasses(Type setType)
+        {
+          // Arrange
+          var config = new AutoConfig();
+
+          var context = new AutoGenerateContext(config);
+
+          context.GenerateType = setType;
+
+          // Act
+          var generator = AutoGeneratorFactory.ResolveGenerator(context);
+
+          var instance = generator.Generate(context);
+
+          // Arrange
+          generator.Should().BeOfType<SetGenerator<int>>();
+
+          instance.Should().BeOfType(setType);
+        }
+      }
+
+      public class List
+      {
+        public class NonGeneric : List<int>
+        {
+        }
+
+        public class GenericWithDifferentType<TType> : List<int>
+        {
+          public TType Property { get; set; }
+        }
+
+        public static IEnumerable<object[]> ListOfListTypes
+        {
+          get
+          {
+            yield return new[] { typeof(NonGeneric) };
+            yield return new[] { typeof(GenericWithDifferentType<string>) };
+          }
+        }
+
+        [Theory]
+        [MemberData(nameof(ListOfListTypes))]
+        public void Should_Handle_Subclasses(Type listType)
+        {
+          // Arrange
+          var config = new AutoConfig();
+
+          var context = new AutoGenerateContext(config);
+
+          context.GenerateType = listType;
+
+          // Act
+          var generator = AutoGeneratorFactory.ResolveGenerator(context);
+
+          var instance = generator.Generate(context);
+
+          // Arrange
+          generator.Should().BeOfType<ListGenerator<int>>();
+
+          instance.Should().BeOfType(listType);
+        }
+      }
+    }
+
     public class ReferenceTypes
       : AutoGeneratorsFixture
     {
@@ -232,6 +445,54 @@ namespace AutoBogus.Tests
       }
     }
 
+    public class ListGenerator
+      : AutoGeneratorsFixture
+    {
+      [Theory]
+      [InlineData(typeof(IList<TestEnum>))]
+      [InlineData(typeof(IList<TestStruct>))]
+      [InlineData(typeof(IList<TestClass>))]
+      [InlineData(typeof(IList<ITestInterface>))]
+      [InlineData(typeof(IList<TestAbstractClass>))]
+      [InlineData(typeof(ICollection<TestEnum>))]
+      [InlineData(typeof(ICollection<TestStruct>))]
+      [InlineData(typeof(ICollection<TestClass>))]
+      [InlineData(typeof(ICollection<ITestInterface>))]
+      [InlineData(typeof(ICollection<TestAbstractClass>))]
+      [InlineData(typeof(List<TestClass>))]
+      public void Generate_Should_Return_List(Type type)
+      {
+        var genericTypes = ReflectionHelper.GetGenericArguments(type);
+        var itemType = genericTypes.ElementAt(0);
+        var generator = CreateGenerator(typeof(ListGenerator<>), itemType);
+        var list = InvokeGenerator(type, generator) as IEnumerable;
+
+        list.Should().NotBeNull().And.NotContainNulls();
+      }
+
+      [Theory]
+      [InlineData(typeof(IList<TestEnum>))]
+      [InlineData(typeof(IList<TestStruct>))]
+      [InlineData(typeof(IList<TestClass>))]
+      [InlineData(typeof(IList<ITestInterface>))]
+      [InlineData(typeof(IList<TestAbstractClass>))]
+      [InlineData(typeof(ICollection<TestEnum>))]
+      [InlineData(typeof(ICollection<TestStruct>))]
+      [InlineData(typeof(ICollection<TestClass>))]
+      [InlineData(typeof(ICollection<ITestInterface>))]
+      [InlineData(typeof(ICollection<TestAbstractClass>))]
+      [InlineData(typeof(List<TestClass>))]
+      public void GetGenerator_Should_Return_ListGenerator(Type type)
+      {
+        var context = CreateContext(type);
+        var genericTypes = ReflectionHelper.GetGenericArguments(type);
+        var itemType = genericTypes.ElementAt(0);
+        var generatorType = GetGeneratorType(typeof(ListGenerator<>), itemType);
+
+        AutoGeneratorFactory.GetGenerator(context).Should().BeOfType(generatorType);
+      }
+    }
+
     public class SetGenerator
       : AutoGeneratorsFixture
     {
@@ -279,8 +540,6 @@ namespace AutoBogus.Tests
       [InlineData(typeof(IEnumerable<TestClass>))]
       [InlineData(typeof(IEnumerable<ITestInterface>))]
       [InlineData(typeof(IEnumerable<TestAbstractClass>))]
-      [InlineData(typeof(ICollection<TestAbstractClass>))]
-      [InlineData(typeof(List<TestClass>))]
       public void Generate_Should_Return_Enumerable(Type type)
       {
         var genericTypes = ReflectionHelper.GetGenericArguments(type);
@@ -297,8 +556,6 @@ namespace AutoBogus.Tests
       [InlineData(typeof(IEnumerable<TestClass>))]
       [InlineData(typeof(IEnumerable<ITestInterface>))]
       [InlineData(typeof(IEnumerable<TestAbstractClass>))]
-      [InlineData(typeof(ICollection<TestAbstractClass>))]
-      [InlineData(typeof(List<TestClass>))]
       public void GetGenerator_Should_Return_EnumerableGenerator(Type type)
       {
         var context = CreateContext(type);

--- a/src/AutoBogus/AutoBogus.csproj
+++ b/src/AutoBogus/AutoBogus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net40;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;net452;netstandard1.3;netstandard2.0</TargetFrameworks>
     <Authors>Nick Dodd</Authors>
     <Company />
     <Product>AutoBogus</Product>
@@ -53,6 +53,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
+    <Reference Include="System.Data.DataSetExtensions" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Reference Include="System.Data.DataSetExtensions" />
   </ItemGroup>
 

--- a/src/AutoBogus/Generators/ListGenerator.cs
+++ b/src/AutoBogus/Generators/ListGenerator.cs
@@ -3,30 +3,30 @@ using System.Collections.Generic;
 
 namespace AutoBogus.Generators
 {
-  internal sealed class SetGenerator<TType>
+  internal sealed class ListGenerator<TType>
     : IAutoGenerator
   {
     object IAutoGenerator.Generate(AutoGenerateContext context)
     {
-      ISet<TType> set;
+      IList<TType> list;
 
       try
       {
-        set = (ISet<TType>)Activator.CreateInstance(context.GenerateType);
+        list = (IList<TType>)Activator.CreateInstance(context.GenerateType);
       }
       catch
       {
-        set = new HashSet<TType>();
+        list = new List<TType>();
       }
 
       var items = context.GenerateMany<TType>();
 
       foreach (var item in items)
       {
-        set.Add(item);
+        list.Add(item);
       }
 
-      return set;
+      return list;
     }
   }
 }

--- a/src/AutoBogus/Generators/ReadOnlyDictionaryGenerator.cs
+++ b/src/AutoBogus/Generators/ReadOnlyDictionaryGenerator.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+
+using AutoBogus.Util;
 
 namespace AutoBogus.Generators
 {
@@ -10,13 +12,18 @@ namespace AutoBogus.Generators
     {
       IAutoGenerator generator = new DictionaryGenerator<TKey, TValue>();
 
+      Type generateType = context.GenerateType;
+
+      if (ReflectionHelper.IsInterface(generateType))
+        generateType = typeof(Dictionary<TKey, TValue>);
+
       // Generate a standard dictionary and create the read only dictionary
       var items = generator.Generate(context) as IDictionary<TKey, TValue>;
 
 #if NET40
       return null;
 #else
-      return new ReadOnlyDictionary<TKey, TValue>(items);
+      return Activator.CreateInstance(generateType, new[] { items });
 #endif
     }
   }

--- a/src/AutoBogus/Util/ReflectionHelper.cs
+++ b/src/AutoBogus/Util/ReflectionHelper.cs
@@ -100,6 +100,42 @@ namespace AutoBogus.Util
       return type.GetGenericTypeDefinition();
     }
 
+    internal static Type GetGenericCollectionType(Type type)
+    {
+      var interfaces = type.GetInterfaces().Where(ReflectionHelper.IsGenericType);
+
+      if (IsInterface(type))
+        interfaces = interfaces.Concat(new[] { type });
+
+      Type dictionaryType = null;
+      Type readOnlyDictionaryType = null;
+      Type listType = null;
+      Type setType = null;
+      Type collectionType = null;
+      Type enumerableType = null;
+
+      foreach (var interfaceType in interfaces.Where(IsGenericType))
+      {
+        if (IsDictionary(interfaceType))
+          dictionaryType = interfaceType;
+        if (IsReadOnlyDictionary(interfaceType))
+          readOnlyDictionaryType = interfaceType;
+        if (IsList(interfaceType))
+          listType = interfaceType;
+        if (IsSet(interfaceType))
+          setType = interfaceType;
+        if (IsCollection(interfaceType))
+          collectionType = interfaceType;
+        if (IsEnumerable(interfaceType))
+          enumerableType = interfaceType;
+      }
+
+      if ((dictionaryType != null) && (readOnlyDictionaryType != null) && IsReadOnlyDictionary(type))
+        dictionaryType = null;
+
+      return dictionaryType ?? readOnlyDictionaryType ?? listType ?? setType ?? collectionType ?? enumerableType;
+    }
+
     internal static bool IsDictionary(Type type)
     {
       var baseType = typeof(IDictionary<,>);
@@ -130,6 +166,12 @@ namespace AutoBogus.Util
     internal static bool IsSet(Type type)
     {
       var baseType = typeof(ISet<>);
+      return IsGenericTypeDefinition(baseType, type);
+    }
+
+    internal static bool IsList(Type type)
+    {
+      var baseType = typeof(IList<>);
       return IsGenericTypeDefinition(baseType, type);
     }
 


### PR DESCRIPTION
This PR:
- Reworks how AutoGeneratorFactory deals with generic collection types, adding a ReflectionHelper method for discovering the actual underlying generic collection interface type.
- Updates ReadOnlyDictionaryGenerator and SetGenerator to create instances of the GenerateType rather than of fixed collection types.
- Adds explicit support for generating IList<T> and related types, along with related methods in ReflectionHelper.
- Adds unit testing of all this functionality, specifically exercising derived types.
- Adds .NET 4.5.2 as a target, because the .NET 4.0 target excludes ReadOnlyDictionary support, but the `.NET45` test project, which targets .NET 4.5.2, can see ReadOnlyDictionary. In general, it would be my expectation that most consumers are using .NET 4.5.2 or newer, and thus would benefit from being able to work with ReadOnlyDictionary.