### PR TITLE
Updated the generation of DataTable row field data to work with other value types

### DIFF
--- a/src/AutoBogus.Tests/AutoGeneratorsFixture.Data.cs
+++ b/src/AutoBogus.Tests/AutoGeneratorsFixture.Data.cs
@@ -181,6 +181,7 @@ namespace AutoBogus.Tests
           Columns.Add(new DataColumn("DoubleColumn", typeof(double)));
           Columns.Add(new DataColumn("DecimalColumn", typeof(decimal)));
           Columns.Add(new DataColumn("DateTimeColumn", typeof(DateTime)));
+          Columns.Add(new DataColumn("DateTimeOffsetColumn", typeof(DateTimeOffset)));
           Columns.Add(new DataColumn("TimeSpanColumn", typeof(TimeSpan)));
           Columns.Add(new DataColumn("StringColumn", typeof(string)));
         }

--- a/src/AutoBogus/Generators/DataTableGenerator.cs
+++ b/src/AutoBogus/Generators/DataTableGenerator.cs
@@ -112,9 +112,7 @@ namespace AutoBogus.Generators
       public abstract object Generate(AutoGenerateContext context);
     }
 
-    class Proxy<T>
-      : Proxy
-      where T : class
+    class Proxy<T> : Proxy
     {
       public override object Generate(AutoGenerateContext context)
         => context.Generate<T>();


### PR DESCRIPTION
DataTableGenerator.cs contains logic to customize the generation of value types by `TypeCode` value, and falls back on a generated proxy to `context.Generate<T>` for unrecognized types. The initial implementation of this includes an unnecessary constraint that `T` be a reference type. This means that columns of types like `DateTimeOffset` will fail.

This PR:
- Updates the automated testing to trigger this problem.
- Removes the constraint on the proxy type, allowing generic `context.Generate<T>` calls with value types.