### PR TITLE
Updated DataSet and DataTable generation to support foreign key relationships

### DIFF
--- a/src/AutoBogus.Tests/AutoGeneratorsFixture.Data.cs
+++ b/src/AutoBogus.Tests/AutoGeneratorsFixture.Data.cs
@@ -42,6 +42,8 @@ namespace AutoBogus.Tests
       {
         yield return new object[] { typeof(DataSet) };
         yield return new object[] { typeof(TypedDataSet) };
+        yield return new object[] { typeof(TypedDataSetWithRelations) };
+        yield return new object[] { typeof(TypedDataSetWithSelfReferencingTable) };
       }
 
       [SkippableTheory]
@@ -86,7 +88,13 @@ namespace AutoBogus.Tests
 
             if (!rowCountByTable.TryGetValue(dataTable, out var count))
             {
-              count = (rowCountByTable.Count + 1) * 10;
+              // Because Table2.RecordID is a Primary Key and this Unique, Table2
+              // must not have more records than Table1 otherwise it is impossible
+              // to have unique values. So, assuming that the dependent tables
+              // come last in the DataSet, we have a decreasing count as we progress
+              // through the list.
+
+              count = 100 - (rowCountByTable.Count + 1) * 10;
 
               rowCountByTable[dataTable] = count;
             }
@@ -118,12 +126,89 @@ namespace AutoBogus.Tests
         }
       }
 
+      [SkippableFact]
+      public void Generate_Should_Fail_If_Requested_Row_Count_Is_Impossible_Due_To_Foreign_Key_Constraint()
+      {
+        // Arrange
+        var dataSetType = typeof(TypedDataSetWithRelations);
+
+        var rowCountByTable = new Dictionary<DataTable, int>();
+
+        Func<AutoGenerateContext, int> rowCountFunctor =
+          (AutoGenerateContext ctx) =>
+          {
+            var dataTable = (DataTable)ctx.Instance;
+
+            if (!rowCountByTable.TryGetValue(dataTable, out var count))
+            {
+              // Because Table2.RecordID is a Primary Key and this Unique, Table2
+              // must not have more records than Table1 otherwise it is impossible
+              // to have unique values. So, assuming that the dependent tables
+              // come last in the DataSet, having an increasing count creates an
+              // impossible situation where there aren't enough related records
+              // to produce unique values.
+
+              count = 100 + (rowCountByTable.Count + 1) * 10;
+
+              rowCountByTable[dataTable] = count;
+            }
+
+            return count;
+          };
+
+        var context = CreateContext(dataSetType, dataTableRowCountFunctor: rowCountFunctor);
+
+        bool success = DataSetGenerator.TryCreateGenerator(context.GenerateType, out var generator);
+
+        Skip.IfNot(success, $"couldn't create generator for {dataSetType.Name}");
+
+        // Act
+        Action action =
+          () => generator.Generate(context);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+          .Which.Message.Should().StartWith("Unable to satisfy the requested row count");
+      }
+
       internal class TypedDataSet : DataSet
       {
         public TypedDataSet()
         {
           Tables.Add(new DataTableGeneratorFacet.TypedDataTable1());
           Tables.Add(new DataTableGeneratorFacet.TypedDataTable2());
+        }
+      }
+
+      internal class TypedDataSetWithRelations : DataSet
+      {
+        public TypedDataSetWithRelations()
+        {
+          var table1 = new DataTableGeneratorFacet.TypedDataTable1();
+          var table2 = new DataTableGeneratorFacet.TypedDataTable2();
+          var table3 = new DataTableGeneratorFacet.TypedDataTable3();
+
+          Tables.Add(table3);
+          Tables.Add(table2);
+          Tables.Add(table1);
+
+          Relations.Add(
+            new DataRelation(relationName: "Relation1", parentColumn: table1.Columns["RecordID"], childColumn: table2.Columns["RecordID"], createConstraints: true));
+          Relations.Add(
+            new DataRelation(relationName: "Relation2", parentColumn: table2.Columns["IntColumn"], childColumn: table3.Columns["ParentIntColumn"], createConstraints: true));
+        }
+      }
+
+      internal class TypedDataSetWithSelfReferencingTable : DataSet
+      {
+        public TypedDataSetWithSelfReferencingTable()
+        {
+          var table = new DataTableGeneratorFacet.TypedDataTable3();
+
+          Tables.Add(table);
+
+          Relations.Add(
+            new DataRelation(relationName: "Relation", parentColumn: table.Columns["RecordID"], childColumn: table.Columns["ParentIntColumn"], createConstraints: true));
         }
       }
     }
@@ -228,6 +313,8 @@ namespace AutoBogus.Tests
           Columns.Add(new DataColumn("UnsignedShortColumn", typeof(ushort)));
           Columns.Add(new DataColumn("IntColumn", typeof(int)));
           Columns.Add(new DataColumn("GuidColumn", typeof(Guid)));
+
+          PrimaryKey = new[] { Columns[0] };
         }
       }
 
@@ -257,12 +344,34 @@ namespace AutoBogus.Tests
           Columns.Add(new DataColumn("DateTimeOffsetColumn", typeof(DateTimeOffset)));
           Columns.Add(new DataColumn("TimeSpanColumn", typeof(TimeSpan)));
           Columns.Add(new DataColumn("StringColumn", typeof(string)));
+
+          PrimaryKey = new[] { Columns[0] };
         }
       }
 
       internal class TypedDataRow2 : DataRow
       {
         public TypedDataRow2(DataRowBuilder builder)
+          : base(builder)
+        {
+        }
+      }
+
+      internal class TypedDataTable3 : TypedTableBase<TypedDataRow3>
+      {
+        public TypedDataTable3()
+        {
+          TableName = "TypedDataTable3";
+
+          Columns.Add(new DataColumn("RecordID", typeof(int)));
+          Columns.Add(new DataColumn("ParentIntColumn", typeof(int)));
+          Columns.Add(new DataColumn("Value", typeof(string)));
+        }
+      }
+
+      internal class TypedDataRow3 : DataRow
+      {
+        public TypedDataRow3(DataRowBuilder builder)
           : base(builder)
         {
         }


### PR DESCRIPTION
This PR:

- Adds unit tests that exercise more complicated scenarios where tables within a `DataSet` have relations configured that can only be satisfied by populating tables in a specific order and making sure that certain columns are given values that match existing records in other tables.
- Updates `DataSetGenerator.cs` to ensure that the order in which tables are generated doesn't violate foreign key relationships.
- Updates `DataTableGenerator.cs` to ensure that column data respects foreign key relationships, including situations where columns are marked `Unique` and tables that reference themselves.

> **NOTE:**
> This branch is based on the `JDG_DataTableRowCount` branch, so the changes from PR #55 will appear here too, but should disappear after that PR is merged.