### PR TITLE
feat: add `WithDateTimeKind` to builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ AutoFaker.Configure(builder =>
 {
   builder
     .WithLocale()         	// Configures the locale to use
+    .WithDateTimeKind()     // Configures the DateTimeKind to use when generating date and time values. Defaults to `DateTimeKind.Local`.
     .WithRepeatCount()    	// Configures the number of items in a collection
     .WithDataTableRowCount()	// Configures the number of data table rows to generate
     .WithRecursiveDepth() 	// Configures how deep nested types should recurse

--- a/src/AutoBogus.Playground/DateTimeKindFixture.cs
+++ b/src/AutoBogus.Playground/DateTimeKindFixture.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using System;
+using Xunit;
+
+namespace AutoBogus.Playground
+{
+  public class DateTimeKindFixture
+  {
+    private sealed class Obj
+    {
+      public DateTime Birthday { get; set; }
+    }
+
+    [Fact]
+    public void Should_ConvertToUtc()
+    {
+      var obj = AutoFaker.Generate<Obj>(builder =>
+      {
+        builder.WithDateTimeKind(DateTimeKind.Utc);
+      });
+
+      obj.Birthday.Should().Be(obj.Birthday.ToUniversalTime());
+    }
+
+    [Fact]
+    public void Should_BeLocal()
+    {
+      var obj = AutoFaker.Generate<Obj>();
+
+      obj.Birthday.Should().Be(obj.Birthday.ToLocalTime());
+    }
+  }
+}

--- a/src/AutoBogus.Tests/AutoConfigBuilderFixture.cs
+++ b/src/AutoBogus.Tests/AutoConfigBuilderFixture.cs
@@ -46,6 +46,27 @@ namespace AutoBogus.Tests
       }
     }
 
+    public class WithDateTimeKind
+      : AutoConfigBuilderFixture
+    {
+      [Fact]
+      public void Should_Set_Config_DateTimeKind()
+      {
+        var kind = DateTimeKind.Utc;
+
+        _builder.WithDateTimeKind<ITestBuilder>(context => kind, null);
+
+        _config.DateTimeKind.Should().Be(kind);
+      }
+
+      [Fact]
+      public void Should_Set_Config_DateTimeKind_To_Default_If_Null()
+      {
+        _builder.WithRepeatCount<ITestBuilder>(null, null);
+        _config.DateTimeKind.Invoke(null).Should().Be(DateTimeKind.Utc);
+      }
+    }
+
     public class WithRepeatCount
       : AutoConfigBuilderFixture
     {
@@ -94,7 +115,7 @@ namespace AutoBogus.Tests
       }
     }
 
-    
+
     public class WithTreeDepth
       : AutoConfigBuilderFixture
     {

--- a/src/AutoBogus/AutoConfig.cs
+++ b/src/AutoBogus/AutoConfig.cs
@@ -10,6 +10,8 @@ namespace AutoBogus
     internal const string DefaultLocale = "en";
     internal const int GenerateAttemptsThreshold = 3;
 
+    internal static readonly Func<AutoGenerateContext, DateTimeKind> DefaultDateTimeKind = context => System.DateTimeKind.Local;
+    // internal static readonly DateTimeKind DefaultDateTimeKind = DateTimeKind.Local;
     internal static readonly Func<AutoGenerateContext, int> DefaultRepeatCount = context => 3;
     internal static readonly Func<AutoGenerateContext, int> DefaultDataTableRowCount = context => 15;
     internal static readonly Func<AutoGenerateContext, int> DefaultRecursiveDepth = context => 2;
@@ -18,6 +20,7 @@ namespace AutoBogus
     internal AutoConfig()
     {
       Locale = DefaultLocale;
+      DateTimeKind = DefaultDateTimeKind;
       RepeatCount = DefaultRepeatCount;
       DataTableRowCount = DefaultDataTableRowCount;
       RecursiveDepth = DefaultRecursiveDepth;
@@ -31,6 +34,7 @@ namespace AutoBogus
     internal AutoConfig(AutoConfig config)
     {
       Locale = config.Locale;
+      DateTimeKind = config.DateTimeKind;
       RepeatCount = config.RepeatCount;
       DataTableRowCount = config.DataTableRowCount;
       RecursiveDepth = config.RecursiveDepth;
@@ -43,6 +47,8 @@ namespace AutoBogus
     }
 
     internal string Locale { get; set; }
+    internal Func<AutoGenerateContext, DateTimeKind> DateTimeKind { get; set; }
+    // internal DateTimeKind DateTimeKind { get; set; }
     internal Func<AutoGenerateContext, int> RepeatCount { get; set; }
     internal Func<AutoGenerateContext, int> DataTableRowCount { get; set; }
     internal Func<AutoGenerateContext, int> RecursiveDepth { get; set; }

--- a/src/AutoBogus/AutoConfig.cs
+++ b/src/AutoBogus/AutoConfig.cs
@@ -11,7 +11,6 @@ namespace AutoBogus
     internal const int GenerateAttemptsThreshold = 3;
 
     internal static readonly Func<AutoGenerateContext, DateTimeKind> DefaultDateTimeKind = context => System.DateTimeKind.Local;
-    // internal static readonly DateTimeKind DefaultDateTimeKind = DateTimeKind.Local;
     internal static readonly Func<AutoGenerateContext, int> DefaultRepeatCount = context => 3;
     internal static readonly Func<AutoGenerateContext, int> DefaultDataTableRowCount = context => 15;
     internal static readonly Func<AutoGenerateContext, int> DefaultRecursiveDepth = context => 2;
@@ -48,7 +47,6 @@ namespace AutoBogus
 
     internal string Locale { get; set; }
     internal Func<AutoGenerateContext, DateTimeKind> DateTimeKind { get; set; }
-    // internal DateTimeKind DateTimeKind { get; set; }
     internal Func<AutoGenerateContext, int> RepeatCount { get; set; }
     internal Func<AutoGenerateContext, int> DataTableRowCount { get; set; }
     internal Func<AutoGenerateContext, int> RecursiveDepth { get; set; }

--- a/src/AutoBogus/AutoConfigBuilder.cs
+++ b/src/AutoBogus/AutoConfigBuilder.cs
@@ -17,6 +17,8 @@ namespace AutoBogus
     internal object[] Args { get; private set; }
 
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithLocale(string locale) => WithLocale<IAutoFakerDefaultConfigBuilder>(locale, this);
+    IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithDateTimeKind(Func<AutoGenerateContext, DateTimeKind> dateTimeKind) => WithDateTimeKind(dateTimeKind, this);
+    IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithDateTimeKind(DateTimeKind dateTimeKind) => WithDateTimeKind(_ => dateTimeKind, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithRepeatCount(int count) => WithRepeatCount<IAutoFakerDefaultConfigBuilder>(context => count, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithRepeatCount(Func<AutoGenerateContext, int> count) => WithRepeatCount<IAutoFakerDefaultConfigBuilder>(count, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithDataTableRowCount(int count) => WithDataTableRowCount<IAutoFakerDefaultConfigBuilder>(context => count, this);
@@ -31,8 +33,10 @@ namespace AutoBogus
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithSkip(Type type, string memberName) => WithSkip<IAutoFakerDefaultConfigBuilder>(type, memberName, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithSkip<TType>(string memberName) => WithSkip<IAutoFakerDefaultConfigBuilder, TType>(memberName, this);
     IAutoFakerDefaultConfigBuilder IAutoConfigBuilder<IAutoFakerDefaultConfigBuilder>.WithOverride(AutoGeneratorOverride generatorOverride) => WithOverride<IAutoFakerDefaultConfigBuilder>(generatorOverride, this);
-    
+
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithLocale(string locale) => WithLocale<IAutoGenerateConfigBuilder>(locale, this);
+    IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithDateTimeKind(Func<AutoGenerateContext, DateTimeKind> dateTimeKind) => WithDateTimeKind(dateTimeKind, this);
+    IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithDateTimeKind(DateTimeKind dateTimeKind) => WithDateTimeKind<IAutoGenerateConfigBuilder>(_ => dateTimeKind, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithRepeatCount(int count) => WithRepeatCount<IAutoGenerateConfigBuilder>(context => count, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithRepeatCount(Func<AutoGenerateContext, int> count) => WithRepeatCount<IAutoGenerateConfigBuilder>(count, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithDataTableRowCount(int count) => WithDataTableRowCount<IAutoGenerateConfigBuilder>(context => count, this);
@@ -47,8 +51,10 @@ namespace AutoBogus
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithSkip(Type type, string memberName) => WithSkip<IAutoGenerateConfigBuilder>(type, memberName, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithSkip<TType>(string memberName) => WithSkip<IAutoGenerateConfigBuilder, TType>(memberName, this);
     IAutoGenerateConfigBuilder IAutoConfigBuilder<IAutoGenerateConfigBuilder>.WithOverride(AutoGeneratorOverride generatorOverride) => WithOverride<IAutoGenerateConfigBuilder>(generatorOverride, this);
-    
+
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithLocale(string locale) => WithLocale<IAutoFakerConfigBuilder>(locale, this);
+    IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithDateTimeKind(Func<AutoGenerateContext, DateTimeKind> dateTimeKind) => WithDateTimeKind(dateTimeKind, this);
+    IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithDateTimeKind(DateTimeKind dateTimeKind) => WithDateTimeKind(_ => dateTimeKind, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithRepeatCount(int count) => WithRepeatCount<IAutoFakerConfigBuilder>(context => count, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithRepeatCount(Func<AutoGenerateContext, int> count) => WithRepeatCount<IAutoFakerConfigBuilder>(count, this);
     IAutoFakerConfigBuilder IAutoConfigBuilder<IAutoFakerConfigBuilder>.WithDataTableRowCount(int count) => WithDataTableRowCount<IAutoFakerConfigBuilder>(context => count, this);
@@ -68,6 +74,12 @@ namespace AutoBogus
     internal TBuilder WithLocale<TBuilder>(string locale, TBuilder builder)
     {
       Config.Locale = locale ?? AutoConfig.DefaultLocale;
+      return builder;
+    }
+
+    internal TBuilder WithDateTimeKind<TBuilder>(Func<AutoGenerateContext, DateTimeKind> kind, TBuilder builder)
+    {
+      Config.DateTimeKind = kind ?? AutoConfig.DefaultDateTimeKind;
       return builder;
     }
 

--- a/src/AutoBogus/Generators/DateTimeGenerator.cs
+++ b/src/AutoBogus/Generators/DateTimeGenerator.cs
@@ -1,11 +1,15 @@
 ﻿namespace AutoBogus.Generators
 {
+  using System;
+
   internal sealed class DateTimeGenerator
     : IAutoGenerator
   {
     object IAutoGenerator.Generate(AutoGenerateContext context)
     {
-      return context.Faker.Date.Recent();
+      return context.Config.DateTimeKind.Invoke(context) == DateTimeKind.Utc
+        ? context.Faker.Date.Recent().ToUniversalTime()
+        : context.Faker.Date.Recent();
     }
   }
 }

--- a/src/AutoBogus/Generators/DateTimeOffsetGenerator.cs
+++ b/src/AutoBogus/Generators/DateTimeOffsetGenerator.cs
@@ -7,7 +7,9 @@ namespace AutoBogus.Generators
   {
     object IAutoGenerator.Generate(AutoGenerateContext context)
     {
-      var dateTime = context.Faker.Date.Recent();
+      var dateTime = context.Config.DateTimeKind.Invoke(context) == DateTimeKind.Utc
+        ? context.Faker.Date.Recent().ToUniversalTime()
+        : context.Faker.Date.Recent();
       return new DateTimeOffset(dateTime);
     }
   }

--- a/src/AutoBogus/IAutoConfigBuilder.cs
+++ b/src/AutoBogus/IAutoConfigBuilder.cs
@@ -18,6 +18,20 @@ namespace AutoBogus
     TBuilder WithLocale(string locale);
 
     /// <summary>
+    /// Registers the DateTimeKind to use when generating date and time values.
+    /// </summary>
+    /// <param name="dateTimeKind">The dateTimeKind to use.</param>
+    /// <returns>The current configuration builder instance.</returns>
+    TBuilder WithDateTimeKind(Func<AutoGenerateContext, DateTimeKind> dateTimeKind);
+
+    /// <summary>
+    /// Registers the DateTimeKind to use when generating date and time values.
+    /// </summary>
+    /// <param name="dateTimeKind">The dateTimeKind to use.</param>
+    /// <returns>The current configuration builder instance.</returns>
+    TBuilder WithDateTimeKind(DateTimeKind dateTimeKind);
+
+    /// <summary>
     /// Registers the number of items to generate for a collection.
     /// </summary>
     /// <param name="count">The repeat count to use.</param>


### PR DESCRIPTION
fixes #83

This lets devs globally set the `DateTimeKind` of generated dates to, for example, more easily accommodate UTC in integration tests.

If #84 is approved, I'll add this toggle to `TimeOnly` as well