### PR TITLE
Extend GenerateUniqueMany  with an EqualityComparer

### DIFF
--- a/src/AutoBogus.Playground/InheritedCaseInsensitiveDictionaryFixture.cs
+++ b/src/AutoBogus.Playground/InheritedCaseInsensitiveDictionaryFixture.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace AutoBogus.Playground
+{
+  public class InheritedCaseInsensitiveDictionaryFixture
+  {
+    public class Obj
+    {
+      public Guid Id { get; set; }
+      public Properties Properties { get; set; }
+    }
+
+    public class Properties : Dictionary<string, string>
+    {
+      public Properties() : base(StringComparer.InvariantCultureIgnoreCase)
+      { }
+
+      public Properties(IDictionary<string, string> dictionary)
+        : base(dictionary, StringComparer.InvariantCultureIgnoreCase)
+      { }
+    }
+
+    [Fact]
+    public void Should_Populate_Object()
+    {
+      // Override string generation to force a duplicate key error on a case insensitive dictionary
+      var keys = new List<string> { "key", "Key", "kEy", "keY" };
+
+      var obj = new AutoFaker<Obj>()
+        .Configure(builder => builder.WithOverride(context => context.Faker.PickRandom(keys)))
+        .Generate();
+
+      obj.Should().NotBeNull();
+      obj.Properties.Should().NotBeNull();
+      obj.Properties.Should().HaveCount(1);
+    }
+  }
+}

--- a/src/AutoBogus/Extensions/AutoGenerateContextExtensions.cs
+++ b/src/AutoBogus/Extensions/AutoGenerateContextExtensions.cs
@@ -56,18 +56,18 @@ namespace AutoBogus
     /// <param name="context">The <see cref="AutoGenerateContext"/> instance for the current generate request.</param>
     /// <param name="count">The number of instances to generate.</param>
     /// <returns>The generated collection of unique instances.</returns>
-    public static List<TType> GenerateUniqueMany<TType>(this AutoGenerateContext context, int? count = null)
+    public static List<TType> GenerateUniqueMany<TType>(this AutoGenerateContext context, int? count = null, IEqualityComparer<TType> comparer = null)
     {
       var items = new List<TType>();
 
       if (context != null)
       {
-        GenerateMany(context, count, items, true);
+        GenerateMany(context, count, items, true, comparer: comparer);
       }
 
       return items;
     }
-    
+
     /// <summary>
     /// Populates the provided instance with generated values.
     /// </summary>
@@ -82,7 +82,7 @@ namespace AutoBogus
       }
     }
 
-    internal static void GenerateMany<TType>(AutoGenerateContext context, int? count, List<TType> items, bool unique, int attempt = 1, Func<TType> generate = null)
+    internal static void GenerateMany<TType>(AutoGenerateContext context, int? count, List<TType> items, bool unique, int attempt = 1, Func<TType> generate = null, IEqualityComparer<TType> comparer = null)
     {
       // Apply any defaults
       if (count == null)
@@ -109,7 +109,7 @@ namespace AutoBogus
       if (unique)
       {
         // Remove any duplicates and generate more to match the required count
-        var filtered = items.Distinct().ToList();
+        var filtered = items.Distinct(comparer ?? EqualityComparer<TType>.Default).ToList();
 
         if (filtered.Count < count)
         {
@@ -120,7 +120,7 @@ namespace AutoBogus
           // Only continue to generate more if the attempts threshold is not reached
           if (attempt < AutoConfig.GenerateAttemptsThreshold)
           {
-            GenerateMany(context, count, items, unique, attempt + 1, generate);
+            GenerateMany(context, count, items, unique, attempt + 1, generate, comparer);
           }
         }
       }

--- a/src/AutoBogus/Generators/DictionaryGenerator.cs
+++ b/src/AutoBogus/Generators/DictionaryGenerator.cs
@@ -18,9 +18,12 @@ namespace AutoBogus.Generators
       {
         items = new Dictionary<TKey, TValue>();
       }
-      
+
+      // Use the configured IEqualityComparer to generate the unique keys
+      var comparer = items is Dictionary<TKey, TValue> dictionary ? dictionary.Comparer : null;
+
       // Get a list of keys
-      var keys = context.GenerateUniqueMany<TKey>();
+      var keys = context.GenerateUniqueMany<TKey>(comparer: comparer);
 
       foreach (var key in keys)
       {


### PR DESCRIPTION
Extend GenerateUniqueMany  with an EqualityComparer to allow for case insensitive Dictionary keys. 

When creating an inherited dictionary with string keys that are case insensitive, the AutoFaker sometimes tries to add duplicate keys to the dictionary. This is because the string comparison used for the generation of the keys is case sensitive.

To resolve this I added an additional IEqualityComparer parameter to the GenerateUniqueMany method and pass this parameter from the DictionaryGenerator.